### PR TITLE
fix: merge newly deployed content

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,4 @@ jobs:
           USERNAME: debian
           PORT: 22
           KEY: ${{ secrets.DEPLOY_SSHKEY }}
-          script: sudo mv /tmp/fatfinger/build/* /var/www/html
+          script: sudo cp -r /tmp/fatfinger/* /var/www/html && rm -r /tmp/fatfinger/*


### PR DESCRIPTION
`mv` won't work if the target directory has a non-empty child directory in it.
instead of bringing in another dependency (`rsync`) just use the plain `cp` command.